### PR TITLE
Remove unnecessary @dynamic lines.

### DIFF
--- a/NYSegmentedControlDemo/NYSegmentedControlDemo/NYSegmentIndicator.m
+++ b/NYSegmentedControlDemo/NYSegmentedControlDemo/NYSegmentIndicator.m
@@ -11,8 +11,6 @@
 
 @implementation NYSegmentIndicator
 
-@dynamic borderColor, borderWidth, cornerRadius;
-
 + (Class)layerClass {
     return [CAGradientLayer class];
 }

--- a/NYSegmentedControlDemo/NYSegmentedControlDemo/NYSegmentedControl.m
+++ b/NYSegmentedControlDemo/NYSegmentedControlDemo/NYSegmentedControl.m
@@ -23,17 +23,6 @@
 
 @implementation NYSegmentedControl
 
-@dynamic borderColor,
-         borderWidth,
-         cornerRadius,
-         numberOfSegments,
-         drawsSegmentIndicatorGradientBackground,
-         segmentIndicatorBackgroundColor,
-         segmentIndicatorGradientTopColor,
-         segmentIndicatorGradientBottomColor,
-         segmentIndicatorBorderColor,
-         segmentIndicatorBorderWidth;
-
 + (Class)layerClass {
     return [CAGradientLayer class];
 }


### PR DESCRIPTION
Since you’re implementing the setters/getters yourself, the use of `@dynamic` us unnecessary. It’s only needed when you’ll provide those implementations at runtime, not compile time.
