### PR TITLE
Added method for simultaneous movement of segmentIndicator

### DIFF
--- a/NYSegmentedControl/NYSegmentedControl.h
+++ b/NYSegmentedControl/NYSegmentedControl.h
@@ -184,4 +184,6 @@
  */
 - (void)setSelectedSegmentIndex:(NSUInteger)selectedSegmentIndex animated:(BOOL)animated;
 
+- (void)moveSelectedSegmentIndicatorSimultaneouslyToIndex:(CGFloat)index;
+
 @end

--- a/NYSegmentedControl/NYSegmentedControl.h
+++ b/NYSegmentedControl/NYSegmentedControl.h
@@ -184,6 +184,6 @@
  */
 - (void)setSelectedSegmentIndex:(NSUInteger)selectedSegmentIndex animated:(BOOL)animated;
 
-- (void)moveSelectedSegmentIndicatorSimultaneouslyToIndex:(CGFloat)index;
+- (void)moveSelectedSegmentIndicatorToSegmentAtIndex:(NSInteger)clearIndex withOffset:(CGFloat)offset;
 
 @end

--- a/NYSegmentedControl/NYSegmentedControl.m
+++ b/NYSegmentedControl/NYSegmentedControl.m
@@ -436,13 +436,13 @@
 
 - (void)triggerMultipleSegmentsBeingScrolledToIndex:(CGFloat)index withOffset:(CGFloat)offset {
     NSInteger direction = index > self.selectedSegmentIndex ? 1 : -1;
-    BOOL scrolledFromLeftToRight = direction == 1;
+    BOOL didScrolledBackward = direction == -1;
     BOOL didScrolledFewSegments = ABS(self.selectedSegmentIndex - (NSInteger)index) > 1;
     
     if (didScrolledFewSegments) {
         NSInteger newIndex = self.selectedSegmentIndex = (index - offset);
         
-        if (!scrolledFromLeftToRight) {
+        if (didScrolledBackward) {
             newIndex = (newIndex + 1) * direction;
         }
         
@@ -461,7 +461,7 @@
         if (offset == 0) { // if no diff from current position then we should move it to the position
             [self setSelectedSegmentIndex:index];
         } else { // when we have dx
-            BOOL scrolledFromLeftToRight = direction == 1;
+            BOOL didScrolledBackward = direction == -1;
             BOOL didScrolledFewSegments = ABS(self.selectedSegmentIndex - clearIndex) > 1;
             
             [self triggerMultipleSegmentsBeingScrolledToIndex:index withOffset:offset];
@@ -476,7 +476,7 @@
                 CGFloat distanceToGo = distance * offset;
                 CGFloat startPosition = sourceSegment.frame.origin.x;
                 
-                if (!scrolledFromLeftToRight && !didScrolledFewSegments) {
+                if (didScrolledBackward && !didScrolledFewSegments) {
                     startPosition -= sourceSegment.frame.size.width;
                 }
                 

--- a/NYSegmentedControl/NYSegmentedControl.m
+++ b/NYSegmentedControl/NYSegmentedControl.m
@@ -435,32 +435,49 @@
 }
 
 - (void)moveSelectedSegmentIndicatorSimultaneouslyToIndex:(CGFloat)index {
-    if (index >= 0 && index <= self.segments.count -1) { // make sure that this code won't work with first and last segments
+    if (index > 0 && index < self.segments.count) { // make sure that this code won't work with first and last segments
         CGFloat diffIndexPercantage = separateLocalIndexDiffFromIndex(index);
+        NSInteger direction = index > self.selectedSegmentIndex ? 1 : -1;
         
         if (diffIndexPercantage == 0) { // if no diff from current position then we should move it to the position
             [self setSelectedSegmentIndex:index];
         } else { // when we have dx
-            NSInteger direction = index > self.selectedSegmentIndex ? 1 : -1;
+            if (ABS(self.selectedSegmentIndex - (NSInteger)index) > 1) {
+                NSInteger newIndex = self.selectedSegmentIndex = (index - diffIndexPercantage);
+                
+                if (direction == -1) {
+                    newIndex = (newIndex + 1) * direction;
+                }
+                
+                if (newIndex >= 0 && newIndex < self.segments.count - 1) {
+                    _selectedSegmentIndex = newIndex;
+                }
+            } 
             
-            NYSegment *segmentFrom = self.segments[self.selectedSegmentIndex];
-            NYSegment *segmentTo = self.segments[self.selectedSegmentIndex + direction];
+            NSInteger nextSegmentIndex = self.selectedSegmentIndex + direction;
             
-            CGFloat distance = ABS(segmentTo.frame.origin.x - segmentFrom.frame.origin.x);
-            CGFloat distanceToGo = distance * diffIndexPercantage;
-            CGFloat startPosition = segmentFrom.frame.origin.x;
-            
-            if (direction == -1) {
-                startPosition -= segmentFrom.frame.size.width;
+            if (nextSegmentIndex >= 0 && nextSegmentIndex < self.segments.count) {
+                NYSegment *segmentFrom = self.segments[self.selectedSegmentIndex];
+                NYSegment *segmentTo = self.segments[self.selectedSegmentIndex + direction];
+                
+                CGFloat distance = ABS(segmentTo.frame.origin.x - segmentFrom.frame.origin.x);
+                CGFloat distanceToGo = distance * diffIndexPercantage;
+                CGFloat startPosition = segmentFrom.frame.origin.x;
+                
+                if (direction == -1) {
+                    startPosition -= segmentFrom.frame.size.width;
+                }
+                
+                self.selectedSegmentIndicator.frame = (CGRect){
+                    startPosition + distanceToGo,
+                    self.selectedSegmentIndicator.frame.origin.y,
+                    self.selectedSegmentIndicator.frame.size.width,
+                    self.selectedSegmentIndicator.frame.size.height
+                };
             }
-            
-            self.selectedSegmentIndicator.frame = (CGRect){
-                startPosition + distanceToGo,
-                self.selectedSegmentIndicator.frame.origin.y,
-                self.selectedSegmentIndicator.frame.size.width,
-                self.selectedSegmentIndicator.frame.size.height
-            };
         }
+    } else {
+        [self setSelectedSegmentIndex:index];
     }
 }
 

--- a/NYSegmentedControl/NYSegmentedControl.m
+++ b/NYSegmentedControl/NYSegmentedControl.m
@@ -434,4 +434,40 @@
     _selectedSegmentIndex = selectedSegmentIndex;
 }
 
+- (void)moveSelectedSegmentIndicatorSimultaneouslyToIndex:(CGFloat)index {
+    if (index >= 0 && index <= self.segments.count -1) { // make sure that this code won't work with first and last segments
+        CGFloat diffIndexPercantage = separateLocalIndexDiffFromIndex(index);
+        
+        if (diffIndexPercantage == 0) { // if no diff from current position then we should move it to the position
+            [self setSelectedSegmentIndex:index];
+        } else { // when we have dx
+            NSInteger direction = index > self.selectedSegmentIndex ? 1 : -1;
+            
+            NYSegment *segmentFrom = self.segments[self.selectedSegmentIndex];
+            NYSegment *segmentTo = self.segments[self.selectedSegmentIndex + direction];
+            
+            CGFloat distance = ABS(segmentTo.frame.origin.x - segmentFrom.frame.origin.x);
+            CGFloat distanceToGo = distance * diffIndexPercantage;
+            CGFloat startPosition = segmentFrom.frame.origin.x;
+            
+            if (direction == -1) {
+                startPosition -= segmentFrom.frame.size.width;
+            }
+            
+            self.selectedSegmentIndicator.frame = (CGRect){
+                startPosition + distanceToGo,
+                self.selectedSegmentIndicator.frame.origin.y,
+                self.selectedSegmentIndicator.frame.size.width,
+                self.selectedSegmentIndicator.frame.size.height
+            };
+        }
+    }
+}
+
+CGFloat separateLocalIndexDiffFromIndex(CGFloat index) {
+    double intPart = 0.0;
+    float localIndex = modf(index, &intPart);
+    return (CGFloat)localIndex;
+}
+
 @end


### PR DESCRIPTION
Added possibility to simultaneously/slightly move segmentIndicator for
use with another scroll view or any of classes inherited from it.

```- (void)moveSelectedSegmentIndicatorToSegmentAtIndex:(NSInteger)clearIndex withOffset:(CGFloat)offset;```

Where clearIndex is NSInteger value of index of for example index of page from some of subclasses of UIScrollView which provide pagination and offset CGFloat is obviously offset scrolled from current to next page of this imaginary UIElement divided by 100% so the value must be between 0 and 1.

This imaginary element could be something like RAPageCollectionViewController from https://github.com/evadne/RAPageViewController
And for example to use it with this segment amount must be the same as pages in PageCollectionViewController and then the code to use them is:
```
- (void)viewDidLoad {
[super viewDidLoad]
    [self addObserver:self forKeyPath:@"displayIndex" options:NSKeyValueObservingOptionNew context:nil];
    // assuming that you have subclassed from RAPageCollectionViewController
}

- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
    CGFloat selectedIndex = [[change objectForKey:@"new"] floatValue];
    CGFloat offset = numbersAfterDotFromFloat(selectedIndex);
    NSInteger index = selectedIndex - offset;

    [self.NYsegmentedControl moveSelectedSegmentIndicatorToSegmentAtIndex:index withOffset:offset];
}

CGFloat numbersAfterDotFromFloat(CGFloat index) {
    double intPart = 0.0;
    float localIndex = modf(index, &intPart);
    return (CGFloat)localIndex;
}
```