### PR TITLE
Removes backgroundcolor

### DIFF
--- a/NYSegmentedControl/NYSegmentedControl.m
+++ b/NYSegmentedControl/NYSegmentedControl.m
@@ -83,7 +83,6 @@
     self.layer.cornerRadius = 4.0f;
     self.layer.borderWidth = 1.0f;
     
-    self.backgroundColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
     self.drawsGradientBackground = NO;
     self.opaque = NO;
     self.segments = [NSArray array];


### PR DESCRIPTION
Background color can be configured by UIAppearance. The control is overriding this in init.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nealyoung/nysegmentedcontrol/14)

<!-- Reviewable:end -->
