### PR TITLE
Using gesture recognizers + dynamically change title color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ profile
 DerivedData
 *.hmap
 *.ipa
-
+.idea/

--- a/NYSegmentedControl/NYSegment.h
+++ b/NYSegmentedControl/NYSegment.h
@@ -10,10 +10,11 @@
 #import <UIKit/UIKit.h>
 
 @class NYSegment;
+@class NYSegmentLabel;
 
 @interface NYSegment : UIView
 
-@property (nonatomic) UILabel *titleLabel;
+@property (nonatomic) NYSegmentLabel *titleLabel;
 
 - (instancetype)initWithTitle:(NSString *)title;
 

--- a/NYSegmentedControl/NYSegment.m
+++ b/NYSegmentedControl/NYSegment.m
@@ -8,6 +8,7 @@
 //
 
 #import "NYSegment.h"
+#import "NYSegmentLabel.h"
 
 static CGFloat const kMinimumSegmentWidth = 68.0f;
 
@@ -25,7 +26,7 @@ static CGFloat const kMinimumSegmentWidth = 68.0f;
     self = [super initWithFrame:frame];
     if (self) {
         self.userInteractionEnabled = NO;
-        self.titleLabel = [[UILabel alloc] initWithFrame:self.frame];
+        self.titleLabel = [[NYSegmentLabel alloc] initWithFrame:self.frame];
         self.titleLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         self.titleLabel.font = [UIFont systemFontOfSize:13.0f];
         self.titleLabel.textAlignment = NSTextAlignmentCenter;

--- a/NYSegmentedControl/NYSegmentIndicator.m
+++ b/NYSegmentedControl/NYSegmentIndicator.m
@@ -19,7 +19,6 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.layer.masksToBounds = YES;
-        self.userInteractionEnabled = NO;
         self.drawsGradientBackground = NO;
         self.opaque = NO;
         self.cornerRadius = 4.0f;

--- a/NYSegmentedControl/NYSegmentLabel.h
+++ b/NYSegmentedControl/NYSegmentLabel.h
@@ -1,0 +1,19 @@
+//
+//  NYSegmentLabel.h
+//  NYSegmentLabel
+//
+//  Copyright (c) 2015 Peter Gammelgaard. All rights reserved.
+//
+//  https://github.com/nealyoung/NYSegmentedControl
+//
+
+#import <Foundation/Foundation.h>
+
+
+@interface NYSegmentLabel : UILabel
+
+@property (nonatomic, strong) UIColor *alternativeTextColor;
+@property (nonatomic, assign) CGRect maskFrame;
+@property (nonatomic, assign) CGFloat maskCornerRadius;
+
+@end

--- a/NYSegmentedControl/NYSegmentLabel.m
+++ b/NYSegmentedControl/NYSegmentLabel.m
@@ -1,0 +1,80 @@
+//
+//  NYSegmentLabel.m
+//  NYSegmentLabel
+//
+//  Copyright (c) 2015 Peter Gammelgaard. All rights reserved.
+//
+//  https://github.com/nealyoung/NYSegmentedControl
+//
+
+
+#import "NYSegmentLabel.h"
+
+@implementation NYSegmentLabel {
+}
+
+- (void)setMaskFrame:(CGRect)maskFrame {
+    _maskFrame = maskFrame;
+
+    [self setNeedsDisplay];
+}
+
+- (void)setMaskCornerRadius:(CGFloat)maskCornerRadius {
+    _maskCornerRadius = maskCornerRadius;
+
+    [self setNeedsDisplay];
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    // Draw text normally
+    [super drawTextInRect:rect];
+
+    if (self.alternativeTextColor) {
+        CGImageRef mask = NULL;
+
+        // Create a mask from the text
+        mask = CGBitmapContextCreateImage(context);
+
+        CGContextSaveGState(context);
+        CGContextTranslateCTM(context, 0, rect.size.height);
+        CGContextScaleCTM(context, 1.0, (CGFloat) -1.0);
+
+        // Clip the current context to our mask
+        CGContextClipToMask(context, rect, mask);
+
+        // Set fill color
+        CGContextSetFillColorWithColor(context, [self.alternativeTextColor CGColor]);
+
+        // Path from mask
+        CGPathRef path = [self pathForRoundedRect:self.maskFrame radius:self.maskCornerRadius];
+        CGContextAddPath(context, path);
+
+        // Fill the path
+        CGContextFillPath(context);
+
+        // Clean up
+        CGContextRestoreGState(context);
+        CGImageRelease(mask);
+    }
+}
+
+- (CGPathRef)pathForRoundedRect:(CGRect)rect radius:(CGFloat)radius
+{
+    if (CGRectIsEmpty(rect)) {
+        return CGPathCreateMutable();
+    }
+    UIBezierPath* path = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:radius];
+    return [path CGPath];
+}
+
+- (UIColor *)alternativeTextColor {
+    if (!_alternativeTextColor) {
+        _alternativeTextColor = self.textColor;
+    }
+    return _alternativeTextColor;
+}
+
+@end

--- a/NYSegmentedControlDemo/NYSegmentedControlDemo.xcodeproj/project.pbxproj
+++ b/NYSegmentedControlDemo/NYSegmentedControlDemo.xcodeproj/project.pbxproj
@@ -19,9 +19,10 @@
 		0E3CBE3C18DECF82001EC237 /* NYSegmentedControlDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E3CBE3B18DECF82001EC237 /* NYSegmentedControlDemoTests.m */; };
 		0E3CBE4918DECFAC001EC237 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E3CBE4618DECFAC001EC237 /* AppDelegate.m */; };
 		0E3CBE4A18DECFAC001EC237 /* DemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E3CBE4818DECFAC001EC237 /* DemoViewController.m */; };
-		C53E59451932DA7100087BCD /* NYSegment.m in Sources */ = {isa = PBXBuildFile; fileRef = C53E59401932DA7100087BCD /* NYSegment.m */; };
-		C53E59461932DA7100087BCD /* NYSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = C53E59421932DA7100087BCD /* NYSegmentedControl.m */; };
-		C53E59471932DA7100087BCD /* NYSegmentIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = C53E59441932DA7100087BCD /* NYSegmentIndicator.m */; };
+		659F21897B4838586BF193C7 /* NYSegment.m in Sources */ = {isa = PBXBuildFile; fileRef = 659F26883AD0F08EA44F6774 /* NYSegment.m */; };
+		659F244CE6F6022E8146667F /* NYSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 659F2880C9CF8CACC71FACF6 /* NYSegmentedControl.m */; };
+		659F2A3F8905B6E980263458 /* NYSegmentLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 659F2E2AD1CACF14B488DE0F /* NYSegmentLabel.m */; };
+		659F2CAA7E8B80BD4171B737 /* NYSegmentIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 659F28C9E7C2C16F3C90C066 /* NYSegmentIndicator.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,12 +54,14 @@
 		0E3CBE4618DECFAC001EC237 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		0E3CBE4718DECFAC001EC237 /* DemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoViewController.h; sourceTree = "<group>"; };
 		0E3CBE4818DECFAC001EC237 /* DemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DemoViewController.m; sourceTree = "<group>"; };
-		C53E593F1932DA7100087BCD /* NYSegment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegment.h; sourceTree = "<group>"; };
-		C53E59401932DA7100087BCD /* NYSegment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegment.m; sourceTree = "<group>"; };
-		C53E59411932DA7100087BCD /* NYSegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegmentedControl.h; sourceTree = "<group>"; };
-		C53E59421932DA7100087BCD /* NYSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegmentedControl.m; sourceTree = "<group>"; };
-		C53E59431932DA7100087BCD /* NYSegmentIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegmentIndicator.h; sourceTree = "<group>"; };
-		C53E59441932DA7100087BCD /* NYSegmentIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegmentIndicator.m; sourceTree = "<group>"; };
+		659F243FA0BCD42CEFAAE8E2 /* NYSegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegmentedControl.h; sourceTree = "<group>"; };
+		659F255C114426B98D821354 /* NYSegmentLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegmentLabel.h; sourceTree = "<group>"; };
+		659F26883AD0F08EA44F6774 /* NYSegment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegment.m; sourceTree = "<group>"; };
+		659F2880C9CF8CACC71FACF6 /* NYSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegmentedControl.m; sourceTree = "<group>"; };
+		659F28C9E7C2C16F3C90C066 /* NYSegmentIndicator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegmentIndicator.m; sourceTree = "<group>"; };
+		659F29086DDA90B516DACA22 /* NYSegmentIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegmentIndicator.h; sourceTree = "<group>"; };
+		659F2E2AD1CACF14B488DE0F /* NYSegmentLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYSegmentLabel.m; sourceTree = "<group>"; };
+		659F2E554A1A4D16DA1FA816 /* NYSegment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYSegment.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,12 +163,14 @@
 		C53E593E1932DA7100087BCD /* NYSegmentedControl */ = {
 			isa = PBXGroup;
 			children = (
-				C53E593F1932DA7100087BCD /* NYSegment.h */,
-				C53E59401932DA7100087BCD /* NYSegment.m */,
-				C53E59411932DA7100087BCD /* NYSegmentedControl.h */,
-				C53E59421932DA7100087BCD /* NYSegmentedControl.m */,
-				C53E59431932DA7100087BCD /* NYSegmentIndicator.h */,
-				C53E59441932DA7100087BCD /* NYSegmentIndicator.m */,
+				659F28C9E7C2C16F3C90C066 /* NYSegmentIndicator.m */,
+				659F2E2AD1CACF14B488DE0F /* NYSegmentLabel.m */,
+				659F26883AD0F08EA44F6774 /* NYSegment.m */,
+				659F2E554A1A4D16DA1FA816 /* NYSegment.h */,
+				659F255C114426B98D821354 /* NYSegmentLabel.h */,
+				659F2880C9CF8CACC71FACF6 /* NYSegmentedControl.m */,
+				659F243FA0BCD42CEFAAE8E2 /* NYSegmentedControl.h */,
+				659F29086DDA90B516DACA22 /* NYSegmentIndicator.h */,
 			);
 			name = NYSegmentedControl;
 			path = ../../NYSegmentedControl;
@@ -268,12 +273,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C53E59451932DA7100087BCD /* NYSegment.m in Sources */,
 				0E3CBE4A18DECFAC001EC237 /* DemoViewController.m in Sources */,
-				C53E59471932DA7100087BCD /* NYSegmentIndicator.m in Sources */,
 				0E3CBE4918DECFAC001EC237 /* AppDelegate.m in Sources */,
 				0E3CBE1D18DECF82001EC237 /* main.m in Sources */,
-				C53E59461932DA7100087BCD /* NYSegmentedControl.m in Sources */,
+				659F2CAA7E8B80BD4171B737 /* NYSegmentIndicator.m in Sources */,
+				659F2A3F8905B6E980263458 /* NYSegmentLabel.m in Sources */,
+				659F21897B4838586BF193C7 /* NYSegment.m in Sources */,
+				659F244CE6F6022E8146667F /* NYSegmentedControl.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Changed to use a pan gesture recogniser to move the selected segment. Further using a tap gesture recogniser to change selection on tap of segment.

The motivation for this change is that gesture recognisers play nicer with each other, which makes it possible to use NYSegmentedControl together with a left menu that uses a pan gesture recogniser for instance. This was not possible with the old implementation.