### PR TITLE
Make sure corner radius is applied to selected segment indicator

### DIFF
--- a/NYSegmentedControl/NYSegmentedControl.m
+++ b/NYSegmentedControl/NYSegmentedControl.m
@@ -129,6 +129,7 @@
     }
 
     self.selectedSegmentIndicator.frame = [self indicatorFrameForSegment:self.segments[self.selectedSegmentIndex]];
+    [self setCornerRadius:[self cornerRadius]];
 }
 
 - (void)drawRect:(CGRect)rect {


### PR DESCRIPTION
If corner radius is applied to the control before the selected segment indicator has been given a frame, the corner radius would not be applied to the indicator. This meant that corner radius had to be set in viewDidAppear: to make sure the control had been properly laid out. With this fix, the control makes sure to apply the corner radius to the selected segment indicator when the view is being laid out.